### PR TITLE
Fix to avoid crashing in sales_order admin grid

### DIFF
--- a/Ui/Component/Columns/OrderGrid.php
+++ b/Ui/Component/Columns/OrderGrid.php
@@ -1,4 +1,4 @@
-<?php
+ç<?php
 
 namespace Konduto\Antifraud\Ui\Component\Columns;
 
@@ -45,7 +45,7 @@ class OrderGrid extends Column
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
                 $item[$this->getData('name')] =
-                    $this->getAttributeValue($item['increment_id'], $this->getData('attributeCode'));
+                    $this->getAttributeValue($item['entity_id'], $this->getData('attributeCode'));
             }
         }
         return $dataSource;


### PR DESCRIPTION
This problem appear on Magento 2.3.3 Enterprise installation.